### PR TITLE
Feat(helpers): add flatten helper function

### DIFF
--- a/helper_functions.py
+++ b/helper_functions.py
@@ -3,4 +3,16 @@ from torch import nn
 
 # Flatten a tensor except for the first dimension (batch size)
 def flatten(x):
-    return x.reshape(x.size(0), -1) # reshape handles non-contiguous tensors
+    """
+    Flatten a tensor except for the first dimension (batch size)
+    Args:
+        x (torch.Tensor): Input tensor of shape (Batch_size, C, H, W)
+
+    Returns:
+        flattened_size (int): Size of the flattened tensor excluding batch size.
+        flattened_tensor (torch.Tensor): Flattened tensor of shape (Batch_size, flattened_size)
+    """
+
+    flattened_size = x.numel() // x.size(0)
+    flattened_tensor = x.reshape(x.size(0), -1)
+    return flattened_size, flattened_tensor  # reshape handles non-contiguous tensors

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -1,0 +1,9 @@
+import torch
+from torch import nn
+
+# Flatten a tensor except for the first dimension (batch size)
+def flatten(x):
+    return x.reshape(x.size(0), -1) # reshape handles non-contiguous tensors
+
+
+print(flatten(torch.randn(4, 64, 8, 8)).shape)  # Example usage

--- a/helper_functions.py
+++ b/helper_functions.py
@@ -4,6 +4,3 @@ from torch import nn
 # Flatten a tensor except for the first dimension (batch size)
 def flatten(x):
     return x.reshape(x.size(0), -1) # reshape handles non-contiguous tensors
-
-
-print(flatten(torch.randn(4, 64, 8, 8)).shape)  # Example usage


### PR DESCRIPTION
### Summary
Adds a helper function `flatten` that automatically flattens CNN outputs
while calculating the flattened size per sample.

### Details
- Input: tensor of shape [batch_size, C, H, W]
- Output: 
  - flattened_tensor: reshaped tensor of shape [batch_size, C*H*W]
  - flattened_size: number of features per sample (C*H*W)
- Uses torch.reshape() for safe handling of non-contiguous tensors.
- Batch-safe: works with any batch size, including 1.
- Eliminates the need to manually calculate C*H*W for fully connected layers.

### Motivation
Simplifies model code and makes it flexible. Changes in convolutional
layers no longer require manual updates to the fully connected layer input size.