### PR TITLE
 Add complex CNN model and pretrained ResNet18 model for CIFAR-10

### DIFF
--- a/cifar10_cnn.ipynb
+++ b/cifar10_cnn.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "id": "06e3dd8c",
    "metadata": {},
    "outputs": [],
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "id": "e4fea721",
    "metadata": {},
    "outputs": [],
@@ -69,40 +69,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 13,
    "id": "6553c8a6",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(tensor([[[-1.0000, -1.0000, -1.0000,  ..., -0.4745, -1.0000, -1.0000],\n",
-       "          [-1.0000, -0.7020, -0.3176,  ..., -0.2549, -0.2471, -1.0000],\n",
-       "          [-0.7412, -0.5373, -0.2000,  ..., -0.1765, -0.2078, -1.0000],\n",
+       "(tensor([[[-1.0000, -0.8039, -0.8745,  ..., -1.0000, -1.0000, -1.0000],\n",
+       "          [-1.0000, -0.7412, -0.7020,  ...,  0.0431, -0.0353, -0.0667],\n",
+       "          [-1.0000, -0.6078, -0.5373,  ...,  0.0196, -0.0745, -0.0588],\n",
        "          ...,\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000]],\n",
+       "          [ 0.3176,  0.4039,  0.4745,  ..., -0.5608, -0.5843, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ..., -0.2392, -0.3490, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ...,  0.1843, -0.0353, -1.0000]],\n",
        " \n",
-       "         [[-1.0000, -1.0000, -1.0000,  ..., -0.6941, -1.0000, -1.0000],\n",
-       "          [-1.0000, -0.8431, -0.5765,  ..., -0.5373, -0.5059, -1.0000],\n",
-       "          [-0.8039, -0.7490, -0.4902,  ..., -0.4588, -0.4824, -1.0000],\n",
+       "         [[-1.0000, -0.8118, -0.9451,  ..., -1.0000, -1.0000, -1.0000],\n",
+       "          [-1.0000, -0.8039, -0.8431,  ..., -0.2471, -0.3098, -0.3490],\n",
+       "          [-1.0000, -0.7490, -0.7490,  ..., -0.2627, -0.3412, -0.3412],\n",
        "          ...,\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000]],\n",
+       "          [ 0.0118,  0.1137,  0.1686,  ..., -0.7569, -0.7333, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ..., -0.5137, -0.5843, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ..., -0.0745, -0.2784, -1.0000]],\n",
        " \n",
-       "         [[-1.0000, -1.0000, -1.0000,  ..., -0.8824, -1.0000, -1.0000],\n",
-       "          [-1.0000, -0.9686, -0.8039,  ..., -0.7725, -0.7098, -1.0000],\n",
-       "          [-0.8667, -0.9137, -0.7333,  ..., -0.7333, -0.7412, -1.0000],\n",
+       "         [[-1.0000, -0.8353, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
+       "          [-1.0000, -0.8667, -0.9686,  ..., -0.5294, -0.5686, -0.6078],\n",
+       "          [-1.0000, -0.8353, -0.9137,  ..., -0.5451, -0.6078, -0.6078],\n",
        "          ...,\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000],\n",
-       "          [-1.0000, -1.0000, -1.0000,  ..., -1.0000, -1.0000, -1.0000]]]),\n",
+       "          [-0.2627, -0.3176, -0.4745,  ..., -0.9451, -0.8431, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ..., -0.7333, -0.7333, -1.0000],\n",
+       "          [-1.0000, -1.0000, -1.0000,  ..., -0.3412, -0.4353, -1.0000]]]),\n",
        " 6)"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "id": "f73c20d5",
    "metadata": {},
    "outputs": [
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "id": "4f93a95a",
    "metadata": {},
    "outputs": [
@@ -160,7 +160,7 @@
        "(50000, 50000, 10000, 10000)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -172,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "2117e13f",
    "metadata": {},
    "outputs": [
@@ -191,7 +191,7 @@
        " 'truck']"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -204,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
    "id": "cef4efc3",
    "metadata": {},
    "outputs": [
@@ -212,13 +212,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-1.0..0.7254902].\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-1.0..0.7254902].\n",
       "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-1.0..0.99215686].\n",
       "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-1.0..0.92156863].\n",
       "Clipping input data to the valid range for imshow with RGB data ([0..1] for floats or [0..255] for integers). Got range [-1.0..0.70980394].\n",
@@ -276,7 +270,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 18,
    "id": "8de99310",
    "metadata": {},
    "outputs": [
@@ -322,10 +316,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 19,
    "id": "ffaec7ce",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SimpleCNN(\n",
+       "  (Conv1): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "  (Conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "  (pool): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "  (linear1): Linear(in_features=4096, out_features=128, bias=True)\n",
+       "  (linear2): Linear(in_features=128, out_features=10, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import torch.nn.functional as F\n",
     "from helper_functions import flatten\n",
@@ -366,37 +377,141 @@
     "        _, x = flatten(x)\n",
     "        x = F.relu(self.linear1(x))\n",
     "        x = self.linear2(x)\n",
-    "        return x"
+    "        return x\n",
+    "        \n",
+    "model_0 = SimpleCNN(input_shape=3,\n",
+    "                    hidden_units=32,\n",
+    "                    output_shape=len(class_names))\n",
+    "model_0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2f370914",
+   "metadata": {},
+   "source": [
+    "# Model 1: Complex CNN\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "5f443a63",
+   "execution_count": null,
+   "id": "989a78d7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "SimpleCNN(\n",
-       "  (Conv1): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (Conv2): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
-       "  (pool): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
-       "  (linear1): Linear(in_features=4096, out_features=128, bias=True)\n",
-       "  (linear2): Linear(in_features=128, out_features=10, bias=True)\n",
+       "ComplexCNN(\n",
+       "  (conv_layers): Sequential(\n",
+       "    (0): Conv2d(3, 32, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (1): BatchNorm2d(32, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (2): ReLU()\n",
+       "    (3): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "    (4): Conv2d(32, 64, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (5): BatchNorm2d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (6): ReLU()\n",
+       "    (7): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "    (8): Conv2d(64, 128, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1))\n",
+       "    (9): BatchNorm2d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "    (10): ReLU()\n",
+       "    (11): MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)\n",
+       "  )\n",
+       "  (classifier): Sequential(\n",
+       "    (0): Linear(in_features=2048, out_features=128, bias=True)\n",
+       "    (1): ReLU()\n",
+       "    (2): Dropout(p=0.5, inplace=False)\n",
+       "    (3): Linear(in_features=128, out_features=10, bias=True)\n",
+       "  )\n",
        ")"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "torch.manual_seed(42)\n",
-    "model_2 = SimpleCNN(input_shape=3, hidden_units=32, output_shape=len(class_names))\n",
+    "class ComplexCNN(nn.Module):\n",
+    "    def __init__(self, input_shape: int, hidden_units: int, output_shape: int):\n",
+    "        super().__init__()\n",
     "\n",
-    "model_2"
+    "        # Convolutional layers with batch normalisation and max pooling\n",
+    "        self.conv_layers = nn.Sequential(\n",
+    "            nn.Conv2d(in_channels=input_shape,\n",
+    "                      out_channels=hidden_units,\n",
+    "                      kernel_size=3,\n",
+    "                      padding=1),\n",
+    "            nn.BatchNorm2d(num_features=hidden_units), # normalise activations of a layer at each batch -> improved training speed and stability\n",
+    "            nn.ReLU(),\n",
+    "            nn.MaxPool2d(kernel_size=2,\n",
+    "                         stride=2),\n",
+    "\n",
+    "            nn.Conv2d(in_channels=hidden_units,\n",
+    "                      out_channels=hidden_units*2,\n",
+    "                      kernel_size=3,\n",
+    "                      padding=1),\n",
+    "            nn.BatchNorm2d(num_features=hidden_units*2),\n",
+    "            nn.ReLU(),\n",
+    "            nn.MaxPool2d(kernel_size=2,\n",
+    "                         stride=2),\n",
+    "\n",
+    "            nn.Conv2d(in_channels=hidden_units*2,\n",
+    "                      out_channels=hidden_units*4,\n",
+    "                      kernel_size=3,\n",
+    "                      padding=1),\n",
+    "            nn.BatchNorm2d(num_features=hidden_units*4),\n",
+    "            nn.ReLU(),\n",
+    "            nn.MaxPool2d(kernel_size=2,\n",
+    "                         stride=2)\n",
+    "            )\n",
+    "            \n",
+    "        # Dynamically calcualte flattened size for fully connected layer\n",
+    "        with torch.no_grad():\n",
+    "            dummy_input = torch.zeros(1, input_shape, 32, 32) # batch size of 1\n",
+    "            x = self.conv_layers(dummy_input)\n",
+    "            flattened_size, _ = flatten(x)\n",
+    "\n",
+    "        # Fully connected layers (Classifier)\n",
+    "        self.classifier = nn.Sequential(\n",
+    "            nn.Linear(flattened_size, hidden_units*4),\n",
+    "            nn.ReLU(),\n",
+    "            nn.Dropout(p=0.5), # randomly zeroes some of the elements of the input tensor with probability p using samples from a Bernoulli distribution -> prevent overfitting\n",
+    "            nn.Linear(hidden_units*4, output_shape)\n",
+    "        )\n",
+    "    \n",
+    "    def forward(self, x):\n",
+    "        x = self.conv_layers(x)\n",
+    "        _, x = flatten(x)\n",
+    "        x = self.classifier(x)\n",
+    "        return x\n",
+    "\n",
+    "model_1 = ComplexCNN(input_shape=3,\n",
+    "                    hidden_units=32,\n",
+    "                    output_shape=len(class_names))\n",
+    "model_1\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2d6ff0fd",
+   "metadata": {},
+   "source": [
+    "# Model 2: Pretrained / Loaded CNN"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "cc8e1736",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torchvision.models as models\n",
+    "from torchvision.models import ResNet18_Weights\n",
+    "\n",
+    "model_2 = models.resnet18(weights=ResNet18_Weights.DEFAULT)\n",
+    "model_2.fc = nn.Linear(in_features=model_2.fc.in_features, out_features=len(class_names))"
    ]
   },
   {
@@ -409,7 +524,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "id": "b0681039",
    "metadata": {},
    "outputs": [],
@@ -418,14 +533,6 @@
     "loss_fn = nn.CrossEntropyLoss()\n",
     "optimizer = torch.optim.SGD(params=model_2.parameters(), lr=0.1)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f9aa8167",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Summary
Adds two additional models for CIFAR-10 classification: 
1. A **Complex CNN** built using `nn.Sequential`, incorporating batch normalisation and dropout
2. A **Pretrained CNN (ResNet18)**, adapted for CIFAR-10 by adjusting the final classification layer

### Details
- **Complex CNN**:
  - Three convolutional layers with batch normalisation and ReLU activations
  - Max Pooling to reduce spatial dimensions
  - Dropout for regularisation
  - Dynamically calculated flattened size for fully connected layers
- **Pretrained CNN**
  - Loads a ResNet18 model pretrained on ImageNet
  - Final fully connected layer modified for `len(class_names)` output classes
- Both models are integrated alongside the existing **Simple CNN** for comparative experimentation

### Motivation
Expands the project to support **model experimentation** and performance comparison
- Complex CNN provides a deeper architecture for improved feature extraction
- Pretrained ResNet18 leverages transfer learning for potentially higher accuracy
- Together, these models make the training pipeline more versatile and scalable